### PR TITLE
Removed the image from the #scoreboard, .inner-gameArea, #answerBank CSS

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -257,9 +257,6 @@ ol {
 .inner-gameArea,
 #answerBank {
   height: 32rem;
-
-  background: url("../images/darth-quiz-hero.png") no-repeat;
-  background-size: cover;
 }
 
 .buttons {


### PR DESCRIPTION
![Hello There Gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2Zsd2Y5aGE4eGZwd3U2dW9oNWhvejhuNXVrZDVkM3d0MTJndHV2MiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3ornk57KwDXf81rjWM/giphy.gif)

# Pull Request

❗![image](https://github.com/DesislavaNaydenova/2405-hackathon-team1-StarWars/assets/131536159/c9e1e065-996a-4f6b-a5a6-96c6f970cb23) ❗️

## Pull Request details:

- Closes issue: #

- I have removed the image from the scoreboard, inner-gameArea and answerbank as it was causing the hero image to be off centered on mobile.

## Any Breaking changes:

- IF ANYTHING YOU'RE COMMITTING WOULD BREAK SOMETHING, INCLUDE HERE WHAT WOULD BREAK
- IF YOU HAVE NO BREAKING CHANGES, ENTER 'None'

## Associated Screenshots:

_( Feel free to add gifs/png screenshots of your feature in action 😊 )_

- IF YOU HAVE ANY SCREENSHOTS, INCLUDE THEM HERE.
- IF YOU HAVE NO SCREENSHOTS, ENTER 'None'
